### PR TITLE
Set timeout for Dependabot PR review job

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -28,6 +28,7 @@ env:
 jobs:
   review-dependabot-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Skip entirely if this PR wasn't opened by Dependabot.
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     env:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow by setting a timeout for the `review-dependabot-pr` job. This helps prevent the job from running indefinitely in case of issues.

* Added a `timeout-minutes: 5` setting to the `review-dependabot-pr` job in `.github/workflows/automerge.yml`.