### PR TITLE
Set timeout for dependency review job to 5 minutes

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -31,6 +31,7 @@ env:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       # Check out the repository so the action can read the manifest files.
       - name: Checkout repository


### PR DESCRIPTION
This pull request makes a minor update to the dependency review workflow by setting a timeout for the job. This helps prevent the workflow from running indefinitely in case of issues.

* Set a 5-minute timeout for the `dependency-review` job in `.github/workflows/dependency-review.yml`