### PR TITLE
Refine comments and adjust dependency review settings

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,17 +3,16 @@
 name: "Dependency review"
 
 # Run on every pull request targeting main.
-# Scans dependency manifest changes (package.json, bun.lockb) against
-# GitHub's advisory database for known CVEs.
+# Scans dependency manifest changes against GitHub's advisory database for known CVEs.
 # When set as a required status check, this blocks automerge (and manual merges)
 # if a vulnerable dependency is introduced -- even via Dependabot patch/minor PRs.
+# Note: no paths filter -- the action exits cleanly when no manifests changed,
+# which keeps the required status check satisfied for all PRs.
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - "package.json"
-      - "bun.lockb"
 
+# https://docs.github.com/en/enterprise-cloud@latest/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
This pull request updates the `dependency-review.yml` workflow to simplify how dependency manifest changes are detected and clarify the workflow's behavior. The most important changes are:

**Workflow behavior and configuration:**

* Removed the `paths` filter so the workflow now runs on every pull request targeting `main`, regardless of whether dependency manifests like `package.json` or `bun.lockb` were changed. This ensures the dependency review status check is always present and passes cleanly when no manifests are modified.
* Updated comments to clarify that the workflow will exit cleanly if no dependency manifests are changed, maintaining a satisfied required status check for all PRs.
* Improved documentation in comments, including a link to the GitHub documentation for the dependency submission API, and removed outdated references to specific manifest files.